### PR TITLE
Added the storage system

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ The `etab` table contains the school name, the Pronote server ID (or the 'rector
 
 `timediff`: The time difference between UTC and your school. Must be updated to match current time. [time.is](https://time.is) is a great website for this. If UTC shows 9AM, and your local time 11AM, then the timediff is 2. (it might change in the future, and **change based on the summer time in your country**)
 
+`storage`: This should be set by default. It is the storage file used by the infos & results module
+
 # Setup
 Edit your crontab with `crontab -e`:
 ```sh
@@ -43,9 +45,9 @@ Edit your crontab with `crontab -e`:
 0 21 * * 0,1,2,3,4 /usr/bin/node /path.to.pronote.dir/courses.js
 # Pronote - Announce homeworks (each day before courses, 8pm)
 0 20 * * 0,1,2,3,4 /usr/bin/node /path.to.pronote.dir/homeworks.js
-# Pronote - Announce new marks & evals (each day, 8pm)
-0 20 * * * /usr/bin/node /path.to.pronote.dir/results.js
-# Pronote - Announce infos (each day, 9pm)
-0 20 * * * /usr/bin/node /path.to.pronote.dir/infos.js
+# Pronote - Check for new marks & evals
+10 * * * * /usr/bin/node /path.to.pronote.dir/results.js
+# Pronote - Check for new infos
+10 * * * * /usr/bin/node /path.to.pronote.dir/infos.js
 ```
 This default configuration will announce courses before each school day at 8pm, and homeworks at 7pm. Values [can be customised here](https://crontab.cronhub.io/).

--- a/credentials.js
+++ b/credentials.js
@@ -18,4 +18,6 @@ const etab = {
 // UTC to Current Time variation. Europe/Paris = 2 on Summer Time, 1 on Winter Time
 const timediff = 2
 
+const storage = './storage.json'
+
 module.exports = { url, username, password, webhook, etab, timediff };

--- a/infos.js
+++ b/infos.js
@@ -2,6 +2,7 @@ const pronote = require('pronote-api')
 const credentials = require('./credentials.js')
 const webhook = require('./webhook.js')
 const timeformat = require('./timeformat.js')
+const storage = require('./storage.js')
 
 async function main()
 {
@@ -23,8 +24,16 @@ async function main()
                     desc = desc+`\n:link: [${file.name}](${file.url})`
                 }
             }
-            webhook.pronoteAnnouncement(info.date, timeformat.toDateSnowflake(info.date), info.title, info.author, desc)
-            await sleep(2500)
+            let check = {
+                "date": info.date,
+                "title": info.title,
+                "author": info.author,
+                "desc": desc
+            }
+            if (storage.autoCheck("info", check) === false) {
+                webhook.pronoteAnnouncement(info.date, timeformat.toDateSnowflake(info.date), info.title, info.author, desc)
+                await sleep(2500)
+            }
         }
     }
 }

--- a/results.js
+++ b/results.js
@@ -2,32 +2,33 @@ const pronote = require('pronote-api');
 const credentials = require('./credentials.js');
 const webhook = require('./webhook.js')
 const timeformat = require('./timeformat.js')
+const storage = require('./storage.js')
 
 async function main()
 {
     const session = await pronote.login(credentials.url, credentials.username, credentials.password);
-    const today = new Date()
-    const startdate = new Date(today)
-    startdate.setDate(startdate.getDate() -1)
-    startdate.setHours(23-credentials.timediff, 50, 0)
-    const enddate = new Date(today)
-    enddate.setDate(enddate.getDate())
-    enddate.setHours(23-credentials.timediff, 50, 0)
     const evals = await session.evaluations();
     const marks = await session.marks();
 
     for (let eval of evals) {
         for (let e of eval.evaluations) {
-            if (e.date > startdate && e.date < enddate) {
-                let levels;
-                if (e.levels == null) {
-                    levels = "Aucune compétence enregistrée."
-                } else {
-                    levels = "Compétences :"
-                    for (let comp of e.levels) {
-                        levels = levels+`\n${comp.name} \`${comp.value.short}\``
-                    }
+            let levels;
+            if (e.levels == null) {
+                levels = "Aucune compétence enregistrée."
+            } else {
+                levels = "Compétences :"
+                for (let comp of e.levels) {
+                    levels = levels + `\n${comp.name} \`${comp.value.short}\``
                 }
+            }
+            let check = {
+                "date": e.date,
+                "subject": eval.name,
+                "teacher": eval.teacher,
+                "name": e.name,
+                "levels": levels
+            }
+            if (storage.autoCheck("eval", check) === false) {
                 webhook.evalResults(e.date, timeformat.toDateSnowflake(e.date), eval.name, eval.teacher, e.name, levels, eval.color)
                 await sleep(2500)
             }
@@ -35,25 +36,31 @@ async function main()
     }
     for (let subject of marks.subjects) {
         for (let mark of subject.marks) {
-            if (mark.date > startdate && mark.date < enddate) {
-                let title = mark.title
-                if (title === "") {
-                    title = "*Sans titre*"
-                }
-                let value = mark.value;
-                if (mark.isAway === true) {
-                    value = "Absent"
-                }
-                let min = mark.min;
-                if (mark.min === -1) {
-                    min = 0
-                }
-                let max = mark.max;
-                if (mark.max === -1) {
-                    max = 0
-                }
-                let markDesc = `Note élève \`${value}\\${mark.scale}\` \nMoyenne classe \`${mark.average}\\${mark.scale}\` \nMinimum \`${min}\` Maximum \`${max}\` \nCoefficient \`${mark.coefficient}\``
-                let avgDesc = `Moy.Gén. ${marks.averages.student} (Classe ${marks.averages.studentClass})`
+            let title = mark.title
+            if (title === "") {
+                title = "*Sans titre*"
+            }
+            let value = mark.value;
+            if (mark.isAway === true) {
+                value = "Absent"
+            }
+            let min = mark.min;
+            if (mark.min === -1) {
+                min = 0
+            }
+            let max = mark.max;
+            if (mark.max === -1) {
+                max = 0
+            }
+            let markDesc = `Note élève \`${value}\\${mark.scale}\` \nMoyenne classe \`${mark.average}\\${mark.scale}\` \nMinimum \`${min}\` Maximum \`${max}\` \nCoefficient \`${mark.coefficient}\``
+            let avgDesc = `Moy.Gén. ${marks.averages.student} (Classe ${marks.averages.studentClass})`
+            let check = {
+                "date": mark.date,
+                "subject": subject.name,
+                "title": title,
+                "mark": markDesc
+            }
+            if (storage.autoCheck("mark", check) === false) {
                 webhook.markResults(mark.date, timeformat.toDateSnowflake(mark.date), subject.name, title, markDesc, avgDesc, subject.color)
                 await sleep(2500)
             }

--- a/storage.js
+++ b/storage.js
@@ -1,0 +1,59 @@
+const fs = require('fs')
+const storage = require('./credentials.js').storage
+
+function read() {
+    checkStorageFile()
+    return(JSON.parse(fs.readFileSync(storage)))
+}
+
+function write(data) {
+    fs.writeFileSync(storage, JSON.stringify(data))
+}
+
+function store(name, data) {
+    let stored = read()
+    if (stored[`${name}`] == null) {
+        stored[`${name}`] = []
+    }
+    stored[`${name}`].push(data)
+    write(stored)
+}
+
+function compare(name, data) {
+    let stored = read()
+    let match = false
+    if (stored[`${name}`] == null) {
+        match = false
+    } else for (let obj of stored[`${name}`]) {
+        if (JSON.stringify(obj) === JSON.stringify(data)) {
+            match = true
+        }
+    }
+    return match
+}
+
+function autoCheck(name, data) {
+    let stored
+    if (compare(name, data) === false) {
+        store(name, data)
+        stored = false
+    } else {
+        stored = true
+    }
+    return stored
+}
+
+function checkStorageFile() {
+    if (fs.existsSync(storage) === false) {
+        let c = {}
+        let content = JSON.stringify(c)
+        fs.writeFileSync(storage, content)
+    }
+    if (fs.readFileSync(storage, 'utf8') === "") {
+        let c = {}
+        let content = JSON.stringify(c)
+        fs.writeFileSync(storage, content)
+    }
+}
+
+module.exports = { read, write, store, compare, autoCheck }


### PR DESCRIPTION
- This commit closes #8 as a workaround has been found
- Add storage.js : The system will store sent messages in a file, defined in credentials.js that will prevent already sent messages to be sent again, letting only new and modified marks/evals/infos, thus letting us refreshing marks, evals, and infos every 10 minutes. (The README.md has been updated accordingly to the changes)